### PR TITLE
Add custom transforms to synchronous transform and swap to synchronous in js tests

### DIFF
--- a/js/tests/swcify.test.ts
+++ b/js/tests/swcify.test.ts
@@ -1,10 +1,15 @@
 /* eslint-env jest */
-import {transformSync} from '..';
+import {transform, transformSync} from '..';
 
 import {trim, trimmed} from './utilities';
 
 const swc = (code, options?) => {
   const output = transformSync(code, options);
+  return output.code;
+};
+
+const swcAsync = async (code, options?) => {
+  const output = await transform(code, options);
   return output.code;
 };
 
@@ -14,6 +19,24 @@ const defaultImport = 'createResolver';
 describe('swcify', () => {
   it('returns JS', () => {
     const code = swc(
+      trimmed`
+      import {foo} from 'bar';
+
+      export function helloWorld() {
+        console.log("hi ", foo);
+      }
+    `,
+    );
+    expect(trim(code)).toMatch(trimmed`
+    import { foo } from 'bar';
+    export function helloWorld() {
+        console.log(\"hi \", foo);
+    }
+  `);
+  });
+
+  it('returns JS Async', async () => {
+    const code = await swcAsync(
       trimmed`
       import {foo} from 'bar';
 

--- a/js/tests/swcify.test.ts
+++ b/js/tests/swcify.test.ts
@@ -64,7 +64,7 @@ describe('swcify', () => {
   });
 });
 
-describe('async transform', () => {
+describe('Custom AsyncTransform', () => {
   it('adds an id prop that returns the require.resolveWeak of the first dynamic import in load', () => {
     const code = trim(`
         import { ${defaultImport} } from '${defaultPackage}';

--- a/js/tests/swcify.test.ts
+++ b/js/tests/swcify.test.ts
@@ -1,10 +1,10 @@
 /* eslint-env jest */
-import {transform} from '..';
+import {transformSync} from '..';
 
 import {trim, trimmed} from './utilities';
 
-const swc = async (code, options?) => {
-  const output = await transform(code, options);
+const swc = (code, options?) => {
+  const output = transformSync(code, options);
   return output.code;
 };
 
@@ -12,8 +12,8 @@ const defaultPackage = '@shopify/async';
 const defaultImport = 'createResolver';
 
 describe('swcify', () => {
-  it('returns JS', async () => {
-    const code = await swc(
+  it('returns JS', () => {
+    const code = swc(
       trimmed`
       import {foo} from 'bar';
 
@@ -30,8 +30,8 @@ describe('swcify', () => {
   `);
   });
 
-  it('respects options', async () => {
-    const code = await swc(
+  it('respects options', () => {
+    const code = swc(
       trimmed`
       async function f() {
       }
@@ -65,7 +65,7 @@ describe('swcify', () => {
 });
 
 describe('async transform', () => {
-  it('adds an id prop that returns the require.resolveWeak of the first dynamic import in load', async () => {
+  it('adds an id prop that returns the require.resolveWeak of the first dynamic import in load', () => {
     const code = trim(`
         import { ${defaultImport} } from '${defaultPackage}';
   
@@ -75,7 +75,7 @@ describe('async transform', () => {
       `);
     expect(
       trim(
-        await swc(code, {
+        swc(code, {
           jsc: {
             target: 'es2020',
           },

--- a/src/transform.rs
+++ b/src/transform.rs
@@ -2,9 +2,10 @@
 // https://github.com/swc-project/swc/blob/master/node/binding/src
 // as such we retain their license in LICENSE.md in this folder
 
+use crate::async_transform::AsyncTransform;
 use crate::{
-  complete_output, get_compiler,
-  util::{CtxtExt, MapErr},
+    complete_output, get_compiler,
+    util::{CtxtExt, MapErr},
 };
 use anyhow::{Context as _, Error};
 use napi::{CallContext, Env, JsBoolean, JsObject, JsString, Task};
@@ -14,121 +15,128 @@ use swc::{try_with_handler, Compiler, TransformOutput};
 use swc_common::{FileName, SourceFile};
 use swc_ecmascript::ast::Program;
 use swc_ecmascript::transforms::pass::noop;
-use crate::{async_transform::AsyncTransform};
+use swc_ecmascript::visit::Fold;
 
 /// Input to transform
 #[derive(Debug)]
 pub enum Input {
-  /// Raw source code.
-  Source(Arc<SourceFile>),
+    /// Raw source code.
+    Source(Arc<SourceFile>),
 }
 
 pub struct TransformTask {
-  pub c: Arc<Compiler>,
-  pub input: Input,
-  pub options: Options,
+    pub c: Arc<Compiler>,
+    pub input: Input,
+    pub options: Options,
 }
 
 impl Task for TransformTask {
-  type Output = TransformOutput;
-  type JsValue = JsObject;
+    type Output = TransformOutput;
+    type JsValue = JsObject;
 
-  fn compute(&mut self) -> napi::Result<Self::Output> {
-    try_with_handler(self.c.cm.clone(), |handler| {
-      self.c.run(|| match self.input {
-        Input::Source(ref s) => {
-          //TODO: replace with chained transforms: chain!(*)
-          let before_pass = AsyncTransform::with_defaults();
-          self.c.process_js_with_custom_pass(
-            s.clone(),
-            &handler,
-            &self.options,
-            before_pass,
-            noop(),
-          )
-        }
-      })
-    })
-    .convert_err()
-  }
+    fn compute(&mut self) -> napi::Result<Self::Output> {
+        try_with_handler(self.c.cm.clone(), |handler| {
+            self.c.run(|| match self.input {
+                Input::Source(ref s) => {
+                    let (before_pass, after_pass) = custom_transforms();
+                    self.c.process_js_with_custom_pass(
+                        s.clone(),
+                        &handler,
+                        &self.options,
+                        before_pass,
+                        after_pass,
+                    )
+                }
+            })
+        })
+        .convert_err()
+    }
 
-  fn resolve(self, env: Env, result: Self::Output) -> napi::Result<Self::JsValue> {
-    complete_output(&env, result)
-  }
+    fn resolve(self, env: Env, result: Self::Output) -> napi::Result<Self::JsValue> {
+        complete_output(&env, result)
+    }
 }
 
 /// returns `compiler, (src / path), options, plugin, callback`
 pub fn schedule_transform<F>(cx: CallContext, op: F) -> napi::Result<JsObject>
 where
-  F: FnOnce(&Arc<Compiler>, String, bool, Options) -> TransformTask,
+    F: FnOnce(&Arc<Compiler>, String, bool, Options) -> TransformTask,
 {
-  let c = get_compiler(&cx);
+    let c = get_compiler(&cx);
 
-  let s = cx.get::<JsString>(0)?.into_utf8()?.as_str()?.to_owned();
-  let is_module = cx.get::<JsBoolean>(1)?;
-  let options: Options = cx.get_deserialized(2)?;
+    let s = cx.get::<JsString>(0)?.into_utf8()?.as_str()?.to_owned();
+    let is_module = cx.get::<JsBoolean>(1)?;
+    let options: Options = cx.get_deserialized(2)?;
 
-  let task = op(&c, s, is_module.get_value()?, options);
+    let task = op(&c, s, is_module.get_value()?, options);
 
-  cx.env.spawn(task).map(|t| t.promise_object())
+    cx.env.spawn(task).map(|t| t.promise_object())
 }
 
 pub fn exec_transform<F>(cx: CallContext, op: F) -> napi::Result<JsObject>
 where
-  F: FnOnce(&Compiler, String, &Options) -> Result<Arc<SourceFile>, Error>,
+    F: FnOnce(&Compiler, String, &Options) -> Result<Arc<SourceFile>, Error>,
 {
-  let c = get_compiler(&cx);
+    let c = get_compiler(&cx);
 
-  let s = cx.get::<JsString>(0)?.into_utf8()?;
-  let is_module = cx.get::<JsBoolean>(1)?;
-  let options: Options = cx.get_deserialized(2)?;
+    let s = cx.get::<JsString>(0)?.into_utf8()?;
+    let is_module = cx.get::<JsBoolean>(1)?;
+    let options: Options = cx.get_deserialized(2)?;
 
-  let output = try_with_handler(c.cm.clone(), |handler| {
-    c.run(|| {
-      if is_module.get_value()? {
-        let program: Program =
-          serde_json::from_str(s.as_str()?).context("failed to deserialize Program")?;
-        c.process_js(&handler, program, &options)
-      } else {
-        let fm = op(&c, s.as_str()?.to_string(), &options).context("failed to load file.")?;
-        c.process_js_file(fm, &handler, &options)
-      }
+    let output = try_with_handler(c.cm.clone(), |handler| {
+        c.run(|| {
+            if is_module.get_value()? {
+                let program: Program =
+                    serde_json::from_str(s.as_str()?).context("failed to deserialize Program")?;
+                c.process_js(&handler, program, &options)
+            } else {
+                let fm =
+                    op(&c, s.as_str()?.to_string(), &options).context("failed to load file.")?;
+                let (before_pass, after_pass) = custom_transforms();
+                c.process_js_with_custom_pass(fm, &handler, &options, before_pass, after_pass)
+            }
+        })
     })
-  })
-  .convert_err()?;
+    .convert_err()?;
 
-  complete_output(cx.env, output)
+    complete_output(cx.env, output)
 }
 
 #[js_function(4)]
 pub fn transform(cx: CallContext) -> napi::Result<JsObject> {
-  schedule_transform(cx, |c, src, _, options| {
-    let input = Input::Source(c.cm.new_source_file(
-      if options.filename.is_empty() {
-        FileName::Anon
-      } else {
-        FileName::Real(options.filename.clone().into())
-      },
-      src,
-    ));
-    TransformTask {
-      c: c.clone(),
-      input,
-      options,
-    }
-  })
+    schedule_transform(cx, |c, src, _, options| {
+        let input = Input::Source(c.cm.new_source_file(
+            if options.filename.is_empty() {
+                FileName::Anon
+            } else {
+                FileName::Real(options.filename.clone().into())
+            },
+            src,
+        ));
+        TransformTask {
+            c: c.clone(),
+            input,
+            options,
+        }
+    })
 }
 
 #[js_function(4)]
 pub fn transform_sync(cx: CallContext) -> napi::Result<JsObject> {
-  exec_transform(cx, |c, src, options| {
-    Ok(c.cm.new_source_file(
-      if options.filename.is_empty() {
-        FileName::Anon
-      } else {
-        FileName::Real(options.filename.clone().into())
-      },
-      src,
-    ))
-  })
+    exec_transform(cx, |c, src, options| {
+        Ok(c.cm.new_source_file(
+            if options.filename.is_empty() {
+                FileName::Anon
+            } else {
+                FileName::Real(options.filename.clone().into())
+            },
+            src,
+        ))
+    })
+}
+
+fn custom_transforms() -> (impl Fold, impl Fold) {
+    let before_pass = AsyncTransform::with_defaults();
+    let after_pass = noop();
+    (before_pass, after_pass)
 }


### PR DESCRIPTION
Only the async `transform(...)` was applying custom transforms. Now both do.
In the short term, js tests will use synchronous transform operation. This should be expanded later.